### PR TITLE
Less than parenthesis syntax requires bash, it is not supported in sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine
-RUN apk --no-cache add curl ca-certificates gettext \
+RUN apk --no-cache add curl ca-certificates gettext bash \
   && curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > /usr/bin/jq && chmod +x /usr/bin/jq
 ADD bin /opt/resource

--- a/bin/in
+++ b/bin/in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . $( dirname "$0" )/common.sh
 


### PR DESCRIPTION
Tested locally by adding `RUN mkdir /code` as the last line in the `Dockerfile`, and used following command to verify
```sh
cat in.json | docker run -i <docker_image> /opt/resource/in /code
```
where `in.json` is in the format described in https://concourse-ci.org/implementing-resource-types.html#resource-in
